### PR TITLE
Remove LABS and xLABS token documentation, streamlining content relat…

### DIFF
--- a/content/docs/2-epicentral-dao/4-core-team.mdx
+++ b/content/docs/2-epicentral-dao/4-core-team.mdx
@@ -5,7 +5,7 @@ description: The Core Team of Epicentral Labs
 
 # Core Team — Procedural Agents of the DAO
 
-The **Core Team** operates as the DAO's designated **procedural agents**, performing ministerial and execution-based tasks approved through the [Epicentral DAO](/docs/2-epicentral-dao). Core Team Members do **not** manage, direct, or control the DAO and hold **no discretionary authority** beyond what [LABS Token Holders](/docs/2-epicentral-dao/2-labs-token) explicitly approve. Their role exists to ensure that passed proposals, once ratified, execute faithfully, accurately, and without discretion beyond the approved parameters.
+The **Core Team** operates as the DAO's designated **procedural agents**, performing ministerial and execution-based tasks approved through the [Epicentral DAO](/docs/2-epicentral-dao). Core Team Members do **not** manage, direct, or control the DAO and hold **no discretionary authority** beyond what [LABS Token Holders](/docs/2-tokens/labs-token) explicitly approve. Their role exists to ensure that passed proposals, once ratified, execute faithfully, accurately, and without discretion beyond the approved parameters.
 
 <Callout title="Procedural Capacity">
     The Core Team's authority exists **only in a Procedural Capacity**, as defined in the Operating Agreement. Core Team Members execute governance-approved tasks without discretionary deviation and hold no ownership, managerial rights, or binding authority.

--- a/content/docs/2-tokens/index.mdx
+++ b/content/docs/2-tokens/index.mdx
@@ -1,0 +1,27 @@
+---
+title: Tokens
+description: Learn about LABS and xLABS tokens
+---
+
+# Tokens
+
+Epicentral Labs uses multiple tokens: **LABS**, **xLABS**, and **wattLABS**. Each token serves a distinct purpose within the ecosystem.
+
+<Cards>
+  <Card
+    title={<span style={{ fontWeight: 'bold', color: '#4a85ff' }}>LABS</span>}
+    description="The governance token that powers Epicentral DAO."
+    href="/docs/2-tokens/labs-token"
+  />
+  <Card
+    title={<span style={{ fontWeight: 'bold', color: '#4a85ff' }}>xLABS</span>}
+    description="The participation-based rewards token earned through staking LABS."
+    href="/docs/2-tokens/xlabs-token"
+  />
+  <Card
+    title={<span style={{ fontWeight: 'bold', color: '#4a85ff' }}>wattLABS</span>}
+    description="An optional wrapped version of LABS for enhanced Solana composability."
+    href="/docs/2-tokens/wattlabs-token"
+  />
+</Cards>
+

--- a/content/docs/2-tokens/labs-token.mdx
+++ b/content/docs/2-tokens/labs-token.mdx
@@ -116,3 +116,4 @@ The vesting contracts are immutable and cannot be modified or canceled. At the t
   The LABS token is **not** a security. The token does not grant equity, governance rights, dividends, or any claim on financial returns. 
   LABS exists solely as a utility token within the Epicentral Labs ecosystem. It is the responsibility of all purchasers and holders to comply with applicable local regulations and to conduct appropriate due diligence prior to participating.
 </Callout>
+

--- a/content/docs/2-tokens/meta.json
+++ b/content/docs/2-tokens/meta.json
@@ -1,0 +1,12 @@
+{
+  "title": "Tokens",
+  "description": "Learn about LABS and xLABS tokens",
+  "root": true,
+  "order": 2,
+  "children": [
+    "2-tokens/labs-token",
+    "2-tokens/xlabs-token",
+    "2-tokens/wattlabs-token"
+  ]
+}
+

--- a/content/docs/2-tokens/wattlabs-token.mdx
+++ b/content/docs/2-tokens/wattlabs-token.mdx
@@ -1,0 +1,15 @@
+---
+title: wattLABS
+description: Optional wrapped version of LABS for enhanced Solana composability
+---
+
+## WATT is wattLABS?
+**wattLABS** (powered by [Watt Protocol](https://watt.si/)) is an optional, wrapped version of LABS that offers additional on-chain flexibility without altering the underlying LABS token or its supply. Converting LABS into wattLABS is a reversible, 1:1 process—holders can unwrap back into LABS at any time.
+
+Once wrapped, **wattLABS** can be used across supported Solana applications. This includes providing liquidity on Raydium and connecting to the Watt Protocol, which operates autonomously to balance markets through algorithmic, non-speculative arbitrage.
+
+## The Future of wattLABS?
+We aim to enable seamless interaction of **wattLABS** with [The Staking Lab](/docs/3-staking-lab) to expand composability and utility for both—not to offer profits, dividends, or expectations of financial return. 
+
+In short, wattLABS enhances LABS’ functional reach across Solana without changing what LABS is—preserving its base characteristics while enabling broader, optional utility. 
+**wattLABS** simply gives LABS holders more ways to participate in decentralized systems while retaining direct control of their tokens.

--- a/content/docs/2-tokens/xlabs-token.mdx
+++ b/content/docs/2-tokens/xlabs-token.mdx
@@ -9,7 +9,7 @@ description: Participation-based Rewards Token
 
 # Rewards Token
 
-**xLABS** is the on-chain reward token that the [Staking Lab](/docs/3-staking-lab) issues to participants who stake [LABS](/docs/2-epicentral-dao/2-labs-token) tokens. 
+**xLABS** is the on-chain reward token that the [Staking Lab](/docs/3-staking-lab) issues to participants who stake [LABS](/docs/2-tokens/labs-token) tokens. 
 The token serves as a proof-of-stake accounting unit that tracks the length of time a user has staked LABS in the [Staking Lab](/docs/3-staking-lab).
 
 ---
@@ -18,7 +18,7 @@ The token serves as a proof-of-stake accounting unit that tracks the length of t
 
 Epicentral Labs designed xLABS to separate governance from participation-based compensation. Staking LABS produces xLABS; holding or transferring xLABS allows participants to decide how, when, and if they engage with the [Rewards Program](/docs/3-staking-lab).
 
-    Users mint xLABS solely through the [Staking Lab](/docs/3-staking-lab) when they stake [LABS](/docs/2-epicentral-dao/2-labs-token), following the predetermined emission logic defined in the protocol code. xLABS emissions remain independent from protocol revenue, fee performance, token price, or any other financial metric. Protocol logic mints xLABS regardless of the number of tokens or assets in the Rewards Program pool.
+    Users mint xLABS solely through the [Staking Lab](/docs/3-staking-lab) when they stake [LABS](/docs/2-tokens/labs-token), following the predetermined emission logic defined in the protocol code. xLABS emissions remain independent from protocol revenue, fee performance, token price, or any other financial metric. Protocol logic mints xLABS regardless of the number of tokens or assets in the Rewards Program pool.
 
     xLABS functions as a transferable participation credential that quantifies and weighs each user's engagement with [Epicentral DAO](/docs/2-epicentral-dao) governance and other verifiable contributions. Holding xLABS grants no rights or claims to profits, dividends, revenue share, equity, debt, redemption value, or any economic return.
 
@@ -102,3 +102,4 @@ xLABS has no pre-allocated supply or vesting schedules. The [Staking Program](/d
 | Classification | Utility governance token    | Proof-of-stake reward token |
 
 ---
+

--- a/content/docs/4-opx/2-fees.mdx
+++ b/content/docs/4-opx/2-fees.mdx
@@ -29,7 +29,7 @@ OPX distributes all collected fees autonomously through smart contract logic. Th
 
 <Accordions type="multiple">
   <Accordion title="Rewards Program — 70%" value="rewards-program">
-    OPX allocates up to seventy percent (70%) of its protocol-designated incentive budgets directly to the [Rewards Program](/docs/3-staking-lab/staking-program/2-reward-calculation-system). These allocations exclusively support the ongoing operation of the Rewards Program. They do not establish, collateralize, or backstop the value of [xLABS](/docs/2-epicentral-dao/3-xlabs-token).
+    OPX allocates up to seventy percent (70%) of its protocol-designated incentive budgets directly to the [Rewards Program](/docs/3-staking-lab/staking-program/2-reward-calculation-system). These allocations exclusively support the ongoing operation of the Rewards Program. They do not establish, collateralize, or backstop the value of [xLABS](/docs/2-tokens/xlabs-token).
     
     The protocol restricts access to the Rewards Program pool to users who satisfy specific participation requirements. OPX makes no guarantee regarding the amount of assets in the pool at any time and does not guarantee that xLABS holders can redeem a predetermined value, quantity, or share of protocol fees.
 
@@ -153,5 +153,5 @@ OPX charges a convenience fee for platform swap functionality:
 This fee applies when users utilize OPX's integrated swap functionality for position management.
 
 <Callout type="warning" title="Disclaimer">
-    None of these allocations constitute token repurchases, token price support, or the provision of financial returns. These fee allocations do not modify or enhance the rights or limitations of [LABS](/docs/2-epicentral-dao/2-labs-token) or [xLABS](/docs/2-epicentral-dao/3-xlabs-token) holders. For comprehensive rights, limitations, and disclaimers, please refer to the official [Terms of Service](/docs/7-terms-of-service).
+    None of these allocations constitute token repurchases, token price support, or the provision of financial returns. These fee allocations do not modify or enhance the rights or limitations of [LABS](/docs/2-tokens/labs-token) or [xLABS](/docs/2-tokens/xlabs-token) holders. For comprehensive rights, limitations, and disclaimers, please refer to the official [Terms of Service](/docs/7-terms-of-service).
 </Callout>


### PR DESCRIPTION
…ed to tokenomics and governance. Update references to LABS and xLABS tokens in the Core Team and OPX fees documentation for consistency. Ensure all content adheres to third-person perspective guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Tokens section in the documentation with dedicated pages for LABS, xLABS, and wattLABS tokens.
  * Introduced wattLABS documentation, describing its wrapped Solana implementation and composability features.
  * Reorganized token documentation structure with updated navigation links across all related pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->